### PR TITLE
build: add SonarQube plugin for code quality analysis

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     id("io.gitlab.arturbosch.detekt") version "1.23.8"
     id("com.diffplug.spotless") version "7.2.1"
     id("org.jetbrains.kotlinx.kover") version "0.9.2"
+    id("org.sonarqube") version "6.3.1.5724"
     application
 }
 


### PR DESCRIPTION
## Summary
- Add SonarQube Gradle plugin v6.3.1.5724 to build configuration
- Minimal setup that supports future SonarCloud CI-based analysis
- Currently works with existing SonarCloud automatic analysis

## Changes
- Single line addition to `build.gradle.kts` plugins block
- No configuration needed with automatic analysis
- Plugin available for future CI integration if needed

## Test Plan
- [x] Build still works with new plugin
- [x] Existing quality checks unaffected
- [x] SonarCloud automatic analysis continues to work