### PR TITLE
docs: add AI agent workflow rules and optimize CI costs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,12 +24,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os:
-        - "ubuntu-latest"
-        - "macos-latest"
-        java:
-        - 17
-        - 21
+        os: ${{ fromJSON(github.event_name == 'pull_request' && '["ubuntu-latest"]' || '["ubuntu-latest", "macos-latest"]') }}
+        java: ${{ fromJSON(github.event_name == 'pull_request' && '[17]' || '[17, 21]') }}
         exclude:
         - os: "macos-latest"
           java: 21

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,36 @@
+# AGENTS.md
+
+<git-workflow-rules>
+  <forbidden>
+    NEVER commit while on main branch
+  </forbidden>
+
+  <required-workflow>
+    0. git branch --show-current (verify not on main)
+    1. git checkout -b new-branch-name
+    2. git add file1 file2 (specific files only)
+    3. git commit -m "type: description"
+    4. git push -u origin new-branch-name
+    5. gh pr create
+  </required-workflow>
+
+  <git-add-rules>
+    NEVER: git add . or git add -A or git add -u
+    ALWAYS: git add path/to/specific/file
+  </git-add-rules>
+
+  <commit-format>
+    Use conventional commits: type: description
+    Examples: feat:, fix:, ci:, docs:, refactor:
+  </commit-format>
+
+  <safety-check>
+    Always run: git branch --show-current
+    If on main: immediately git checkout -b new-branch
+  </safety-check>
+
+  <ship-it-definition>
+    When user says "ship it": execute full workflow above and open PR
+    Expected delivery: Pull Request created and ready for review
+  </ship-it-definition>
+</git-workflow-rules>


### PR DESCRIPTION
## Summary
- Add `AGENTS.md` with XML-formatted git workflow rules for AI agents
- Optimize CI matrix to run only ubuntu-17 for PRs (~67% cost reduction)
- Enforce conventional commits and specific file staging rules
- Define "ship it" workflow expectations

## Changes
- **CI Optimization**: PRs now run 1 job instead of 3, main branch keeps full coverage
- **Agent Rules**: Clear XML-structured rules to prevent main branch commits
- **Workflow Definition**: Explicit "ship it" means create PR as deliverable

## Test Plan
- [x] YAML syntax validated with yq
- [x] Conventional commit format used
- [x] Specific file staging (no wildcards)
- [x] PR created as expected deliverable