### PR TITLE
feat: add lintFix task for auto-correcting code quality issues

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,3 +34,15 @@
     Expected delivery: Pull Request created and ready for review
   </ship-it-definition>
 </git-workflow-rules>
+
+<test-debugging>
+  For test debugging with println: MUST run with --info flag
+  Example: ./gradlew test --tests "*SomeTest*" --console=plain --info
+  Without --info flag, println output will not be visible in test results
+</test-debugging>
+
+<code-quality>
+  ./gradlew lint - Check for issues (no changes)
+  ./gradlew lintFix - Auto-fix all correctable lint and formatting issues
+  Order: Spotless formatting first, then Detekt auto-correct
+</code-quality>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -252,9 +252,10 @@ tasks.register<io.gitlab.arturbosch.detekt.Detekt>("detektAutoCorrect") {
 tasks.register("lintFix") {
     description = "Fix all auto-correctable lint and formatting issues"
     group = "formatting"
-    dependsOn("spotlessApply")
-    finalizedBy("detektAutoCorrect")
+    dependsOn("spotlessApply", "detektAutoCorrect")
 }
+
+tasks.named("detektAutoCorrect").configure { mustRunAfter("spotlessApply") }
 
 tasks.register("format") {
     description = "Format all source code"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -234,6 +234,28 @@ tasks.register("lint") {
     dependsOn("detekt", "spotlessCheck")
 }
 
+tasks.register<io.gitlab.arturbosch.detekt.Detekt>("detektAutoCorrect") {
+    description = "Run detekt with auto-correct enabled"
+    parallel = true
+    config.setFrom(files("detekt.yml"))
+    buildUponDefaultConfig = true
+    setSource(files("src"))
+    autoCorrect = true
+    reports {
+        // Disable reports for auto-correct run to keep output clean
+        html.required.set(false)
+        xml.required.set(false)
+        sarif.required.set(false)
+    }
+}
+
+tasks.register("lintFix") {
+    description = "Fix all auto-correctable lint and formatting issues"
+    group = "formatting"
+    dependsOn("spotlessApply")
+    finalizedBy("detektAutoCorrect")
+}
+
 tasks.register("format") {
     description = "Format all source code"
     group = "formatting"


### PR DESCRIPTION
## Summary
- Add `lintFix` task that auto-fixes all correctable lint and formatting issues
- Proper orchestration: Spotless formatting first, then Detekt auto-correct
- Document usage in AGENTS.md for team reference

## Implementation Details
- **detektAutoCorrect**: New task that runs detekt with `--auto-correct` flag
- **lintFix**: Orchestrates `spotlessApply` → `detektAutoCorrect` in correct order
- Clean separation from existing `lint` task (check-only vs fix)

## Usage
```bash
./gradlew lint      # Check for issues (no changes)
./gradlew lintFix   # Auto-fix all correctable issues
```

## Test Plan
- [x] Task executes without errors
- [x] Proper task ordering (format → analyze/fix)
- [x] Auto-correctable issues are fixed
- [x] Non-correctable issues are reported
- [x] No conflicts between Spotless and Detekt