### PR TITLE
feat: integrate SonarCloud coverage reporting in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,12 +57,10 @@ jobs:
     - name: "Run Code Coverage"
       run: "./gradlew koverHtmlReport koverXmlReport --stacktrace"
     - name: "SonarCloud Analysis"
-      if: |
-        matrix.os == 'ubuntu-latest' && matrix.java == 17 &&
-        ((github.event_name == 'push' && github.ref == 'refs/heads/main') ||
-         (github.event_name == 'pull_request' &&
-          github.event.pull_request.base.ref == 'main' &&
-          github.event.pull_request.head.repo.full_name == github.repository))
+      if: "matrix.os == 'ubuntu-latest' && matrix.java == 17 &&\n((github.event_name\
+        \ == 'push' && github.ref == 'refs/heads/main') ||\n (github.event_name ==\
+        \ 'pull_request' &&\n  github.event.pull_request.base.ref == 'main' &&\n \
+        \ github.event.pull_request.head.repo.full_name == github.repository))\n"
       env:
         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         SONAR_TOKEN: "${{ secrets.SONAR_TOKEN }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,17 @@ jobs:
       run: "./gradlew test --stacktrace"
     - name: "Run Code Coverage"
       run: "./gradlew koverHtmlReport koverXmlReport --stacktrace"
+    - name: "SonarCloud Analysis"
+      if: |
+        matrix.os == 'ubuntu-latest' && matrix.java == 17 &&
+        ((github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+         (github.event_name == 'pull_request' &&
+          github.event.pull_request.base.ref == 'main' &&
+          github.event.pull_request.head.repo.full_name == github.repository))
+      env:
+        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        SONAR_TOKEN: "${{ secrets.SONAR_TOKEN }}"
+      run: "./gradlew sonar --info"
     - name: "Generate Test Report"
       uses: "dorny/test-reporter@v2"
       if: "success() || failure()"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,12 +38,11 @@
 <local-git-ignore>
   File: .git/info/exclude (local ignore, not shared with others)
 
-  Add files/folders that should be ignored only on your machine:
-  echo "filename.ext" >> .git/info/exclude
-  echo "folder-name/" >> .git/info/exclude
+Add files/folders that should be ignored only on your machine: echo "filename.ext" >> .git/info/exclude echo
+"folder-name/" >> .git/info/exclude
 
-  Use for: local dev files, personal notes, temp directories
-  NOT for: files all developers should ignore (use .gitignore instead)
+Use for: local dev files, personal notes, temp directories NOT for: files all developers should ignore (use .gitignore
+instead)
 
   <default-behavior>
     When asked to "ignore a file" or "add to ignore": ALWAYS use .git/info/exclude

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,22 @@
   </ship-it-definition>
 </git-workflow-rules>
 
+<local-git-ignore>
+  File: .git/info/exclude (local ignore, not shared with others)
+
+  Add files/folders that should be ignored only on your machine:
+  echo "filename.ext" >> .git/info/exclude
+  echo "folder-name/" >> .git/info/exclude
+
+  Use for: local dev files, personal notes, temp directories
+  NOT for: files all developers should ignore (use .gitignore instead)
+
+  <default-behavior>
+    When asked to "ignore a file" or "add to ignore": ALWAYS use .git/info/exclude
+    Only use .gitignore when explicitly told "add to .gitignore"
+  </default-behavior>
+</local-git-ignore>
+
 <test-debugging>
   For test debugging with println: MUST run with --info flag
   Example: ./gradlew test --tests "*SomeTest*" --console=plain --info


### PR DESCRIPTION
## Summary
- Fixes 0% coverage issue in SonarCloud by adding analysis step to CI workflow
- Ensures coverage reports are generated before SonarCloud analysis runs
- Configured to run only once per commit (ubuntu-latest + Java 17) to avoid matrix duplication

## Changes
- Add SonarCloud analysis step to `.github/workflows/ci.yml` after coverage generation
- Step runs on main branch pushes and PRs targeting main (excludes forks for security)
- Uses existing Kover XML reports at `build/reports/kover/report.xml`

## Test plan
- [ ] Configure SONAR_TOKEN secret in repository settings
- [ ] Merge PR and push to main to trigger SonarCloud analysis
- [ ] Verify coverage appears in SonarCloud dashboard (should show actual % instead of 0%)
- [ ] Test PR decoration by creating a test PR

## Requirements
- SONAR_TOKEN must be set in GitHub repository secrets before merging