### PR TITLE
feat: add gradle-pre-commit-git-hooks with auto-fix capabilities

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,27 @@
 # AGENTS.md
 
+<github-cli-ironclad>
+  MUST use GitHub CLI exclusively for reading GitHub content. NEVER use WebFetch for GitHub.
+
+# Repository metadata
+
+gh api repos/owner/repo --jq '.description, .topics, .homepage' gh api repos/owner/repo/releases/latest --jq '.tag_name,
+.published_at'
+
+# File content (base64 decode)
+
+gh api repos/owner/repo/contents/path/to/file.md --jq '.content' | base64 -d gh api repos/owner/repo/contents/README.md
+--jq '.content' | base64 -d
+
+# Search and exploration
+
+gh api repos/owner/repo/contents/path --jq '.[] | select(.type=="file") | .name' gh search repos "gradle hooks
+language:kotlin" --limit 5 gh search repos --language=kotlin --topic=gradle --limit 5
+
+# Raw content with --jq for processing
+
+gh api repos/owner/repo/contents/build.gradle.kts --jq '.download_url' | xargs curl -s </github-cli-ironclad>
+
 <git-workflow-rules>
   <forbidden>
     NEVER commit while on main branch

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,1 +1,37 @@
+plugins {
+    id("org.danilopianini.gradle-pre-commit-git-hooks") version "2.1.2"
+}
+
+gitHooks {
+    preCommit {
+        from {
+            """
+            #!/bin/sh
+            # Cross-platform: sh works on all systems via Git
+
+            # Check not on main branch (works on Windows/Mac/Linux)
+            branch=${'$'}(git rev-parse --abbrev-ref HEAD)
+            if [ "${'$'}branch" = "main" ]; then
+                echo "ERROR: Direct commits to main branch are forbidden!"
+                echo "Please create a feature branch: git checkout -b your-branch-name"
+                exit 1
+            fi
+
+            echo "Running code quality checks..."
+            """
+        }
+        // Use Gradle wrapper - works cross-platform
+        tasks("spotlessCheck", "detekt")
+    }
+
+    commitMsg {
+        conventionalCommits {
+            // Supports: feat, fix, build, chore, ci, docs, perf, refactor, revert, style, test
+            defaultTypes()
+        }
+    }
+
+    createHooks(true) // Allow overwriting existing hooks
+}
+
 rootProject.name = "groovy-lsp"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -17,11 +17,24 @@ gitHooks {
                 exit 1
             fi
 
-            echo "Running code quality checks..."
+            echo "Running auto-formatting and code quality fixes..."
+
+            # Store list of staged files
+            staged_files=${'$'}(git diff --cached --name-only --diff-filter=d)
+
+            # Run auto-fixers (spotlessApply + detektAutoCorrect)
+            ./gradlew lintFix --quiet || exit 1
+
+            # Re-stage modified files
+            for file in ${'$'}staged_files; do
+                if [ -f "${'$'}file" ]; then
+                    git add "${'$'}file"
+                fi
+            done
+
+            echo "✓ Code formatting applied and files re-staged"
             """
         }
-        // Use Gradle wrapper - works cross-platform
-        tasks("spotlessCheck", "detekt")
     }
 
     commitMsg {


### PR DESCRIPTION
## Summary
- Implements cross-platform pre-commit hooks using gradle-pre-commit-git-hooks plugin
- Automatically formats code using `lintFix` (combines `spotlessApply` + `detektAutoCorrect`)
- Prevents commits directly to main branch
- Enforces conventional commit messages with helpful error messages
- Re-stages files after auto-formatting for seamless developer workflow

## Key Features
- **Auto-fix workflow**: Runs `./gradlew lintFix --quiet` and re-stages modified files
- **Cross-platform**: Uses `#!/bin/sh` compatible with Git Bash on Windows
- **Zero friction**: Developers never see formatting errors, hooks fix them automatically
- **Conventional commits**: Enforces standard commit types (feat, fix, chore, etc.)
- **Branch protection**: Prevents accidental commits to main branch

## Technical Implementation
- Plugin configured in `settings.gradle.kts`
- Hooks auto-install when project is imported/synced
- No external dependencies (Python not required)
- Leverages existing project tasks (`lintFix`, `spotlessApply`, `detektAutoCorrect`)

## Test Plan
- [x] Hooks install automatically when running Gradle
- [x] Auto-formatting works and re-stages files
- [x] Branch protection prevents main branch commits
- [x] Conventional commit validation with helpful messages
- [x] Cross-platform shell script compatibility