### PR TITLE
feat: add Makefile with development shortcuts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,55 @@
+# Groovy LSP Makefile
+# Quick development commands for common tasks
+
+.PHONY: help build jar test clean lint format quality run-stdio run-socket version
+
+# Default target
+help:
+	@echo "Available targets:"
+	@echo "  jar        - Build fat JAR without running tests (quick refresh)"
+	@echo "  build      - Full build including tests"
+	@echo "  test       - Run all tests"
+	@echo "  clean      - Clean build artifacts"
+	@echo "  lint       - Run code quality checks"
+	@echo "  format     - Format source code"
+	@echo "  quality    - Run all quality checks including coverage"
+	@echo "  run-stdio  - Run server in stdio mode"
+	@echo "  run-socket - Run server in socket mode (port 8080)"
+	@echo "  version    - Show version information"
+
+# Quick JAR build without tests (most common during development)
+jar:
+	./gradlew build -x test
+
+# Full build with tests
+build:
+	./gradlew build
+
+# Run tests only
+test:
+	./gradlew test
+
+# Clean build artifacts
+clean:
+	./gradlew clean
+
+# Code quality
+lint:
+	./gradlew lint
+
+format:
+	./gradlew lintFix
+
+quality:
+	./gradlew quality
+
+# Run the language server
+run-stdio: jar
+	java -jar build/libs/groovy-lsp-*-SNAPSHOT.jar
+
+run-socket: jar
+	java -jar build/libs/groovy-lsp-*-SNAPSHOT.jar socket 8080
+
+# Version information
+version:
+	./gradlew printVersion


### PR DESCRIPTION
## Summary
- Add Makefile with convenient targets for common development tasks
- Provides quick shortcuts like `make jar` for fast builds and `make run-stdio` for testing
- Includes all standard targets: build, test, lint, format, quality, clean, version

## Test plan
- [x] Verify Makefile syntax and targets work correctly
- [x] Test `make jar` builds without running tests (faster development cycle)  
- [x] Test `make run-stdio` launches server properly
- [x] Confirm all targets map to correct gradle commands